### PR TITLE
Staging Update

### DIFF
--- a/atc-guide/tower/departures.md
+++ b/atc-guide/tower/departures.md
@@ -57,7 +57,7 @@ When there are multiple aircraft queuing for departure, it can be useful to prov
 
 Manual
 
-: Any aircraft that is instructed to LUAW or cleared for take-off is no longer considered in the departure sequence - therefore the next aircraft at the hold short line is now considered number 1 for departure. [More info?](/guide/atc-manual/3.-tower/3.2-departures#3.2.2)
+: An aircraft that has been cleared for take-off is no longer considered in the departure sequence - therefore the next aircraft holding short is considered number 1 for departure. However, if an aircraft has been instructed to LUAW, the next aircraft holding short is considered number 2 for departure. [More info?](/guide/atc-manual/3.-tower/3.2-departures#3.2.2)
 
 
 

--- a/atc-manual/7.-recruitment-and-training/7.4-promotion-to-specialist-(check-ride).md
+++ b/atc-manual/7.-recruitment-and-training/7.4-promotion-to-specialist-(check-ride).md
@@ -22,7 +22,7 @@ The probation period **should not**{.red} exceed 7 days, unless it is due to Mod
 
  -    **Must**{.red} control Bravo classification airports where possible (Charlie classification airports are acceptable if they provide for adequate evaluation)
  -    **Must**{.red} control on a regular basis (at least 3 separate occasions)
- -    **Must not**{.red} control FNF (Friday Night Flight), FF (Flash Flight) or Twitch steam featured airports 
+ -    **Must not**{.red} control FNF (Friday Night Flight) hubs, FF (Flash Flight) or Twitch steam featured airports 
 
 
 

--- a/atc-manual/index.md
+++ b/atc-manual/index.md
@@ -28,7 +28,7 @@ Should
 
 ## ATC Manual Version (Internal): 21.3.0.1
 
-## Last Updated: 1000Z - 13 JUL 21
+## Last Updated: 1730Z - 16 JUL 21
 
 
 
@@ -85,5 +85,4 @@ Should
 | 7D.4.2          | Guidance for Supervisors on issuing feedback                 |
 
 +++
-
 


### PR DESCRIPTION
IMPROVED
- Adjusted wording in ATC Manual to clarify that FNF hubs cannot be opened if in the check ride phase

FIXED
- Amended wording in the ATC Guide on departure sequencing to match the ATC Manual