### PR TITLE
Added manual reference (3.4.1)

### DIFF
--- a/flying-guide/atc-communication/remaining-in-the-pattern.md
+++ b/flying-guide/atc-communication/remaining-in-the-pattern.md
@@ -65,6 +65,10 @@ Step 5
 ![Sequence and Clearance](_images/manual/frames/sequence-and-clearance.png)
 
 
+Manual
+
+: Make sure you are flying at the correct altitude while remaining in the pattern. The pattern altitude is 1000ft AAL (above aerodrome level) for props and 1500ft AAL for jets. [More info?](https://infiniteflight.com/guide/atc-manual/3.-tower/3.4-pattern-work-transitions-flight-of-xx#3.4.1)
+
 
 ## Remaining in the Pattern Communication Tables
 


### PR DESCRIPTION
**Location**

[Flying Guide - ATC Communication - Remaining in the Pattern](https://infiniteflight.com/guide/flying-guide/atc-communication/remaining-in-the-pattern) at the bottom of the "Remaining in the Pattern Communication Summary". 

**Proposed Changes**

Added a reference to 3.4.1 in the ATC Manual on pattern altitude. 