### PR TITLE
Added tip to distinguish left and right traffic

### DIFF
--- a/atc-guide/tower/inbounds.md
+++ b/atc-guide/tower/inbounds.md
@@ -35,11 +35,11 @@ The art of sequencing allows controllers to let pilots know who they are suppose
 - the pilots to be courteous to each other by giving each pilot the space they need to maneuver
 - the pilots to follow the issued sequence
 
+Tip 
 
+: When you’re on left downwind the airport will be on your left and when you’re on right downwind the airport will be on your right. The same thing applies for the crosswind and base leg of the traffic pattern. 
 
 ![Image 3.3.1.1 - Tower Sequencing](_images/manual/graphics/atc-tower-sequencing.jpg)
-
-
 
 Manual
 


### PR DESCRIPTION
**Location** 

[ATC Guide - Inbounds - Pattern Entry, Sequence and Clearance](https://infiniteflight.com/guide/atc-guide/tower/inbounds#pattern-entry%2C-sequence-and-clearance)

**Purposed Changes**

Added a tip/trick used to remember what the difference between left and right downwind/crosswind/base is, as it can be confusing for new people.